### PR TITLE
Added CSV file integration for incoming data

### DIFF
--- a/receiver.py
+++ b/receiver.py
@@ -53,7 +53,7 @@ async def _csv_writer(queue: asyncio.Queue, file_name: str ):
                 flush_counter = 0
 
 
-async def csv_writer(queue: asyncio.Queue, side: str):
+def csv_writer(queue: asyncio.Queue, side: str):
     """ Write data from the queue to a csv file. 
 
     Args:
@@ -91,7 +91,7 @@ async def csv_writer(queue: asyncio.Queue, side: str):
         with open(data_file, "w") as f:
             f.write(f"{DATA_HEADER}\n")
             
-    await _csv_writer(queue, data_file)
+    asyncio.create_task(_csv_writer(queue, data_file))
 
 
 def print_data(bluetooth_data: list) -> None:
@@ -204,8 +204,8 @@ async def connect(device_name, uuid, queue):
     nano = await wait_for_nano(device_name)
     print(f"Found GIK {side} Hand")
     
-    # Start ssv writers
-    asyncio.create_task(csv_writer(queue, side))
+    # Start csv writers
+    csv_writer(queue, side)
     
     # Main bluetooth loop
     while True:


### PR DESCRIPTION
### ** Added CSV file saving for the incoming Bluetooth data in `receiver.py`** 

### Architecture:

Implements two `async` functions, which picks up data from a `queue` and writes it to two seperate csv files-- one for the Right hand and one for the Left hand. 

`handler` function from before now just pushes data it receives to the `queue` 

This decouples our writting logic from the bluetooth receiving logic, and it's a good idea because writting to the file may be slower than receiving data from the nano via bluetooth, so thus our writers are not a bottleneck with this architecture.

### Changelog:
1) Creates a new csv file every time we form a new connection by incrementing a `session_id` stored in `\data\metadata_{Left or Right}.txt`. 
 
2) In case something crashes we can **override** "the creation of a new csv file every session" and pass on a `session_id` to the program and it will pick that CSV file from `\data`, and append to it instead of creating a new one with a new `session_id`. 

This makes dealing with crashes easier and is also why I chose to go with a `session_id` that is `int` rather than a timestamp to name our `csv` files.  We can also have better naming schemes if required, like integrating both or naming the most recent file `latest_Left.csv' so its easy to spot in the directory. 

3) Added constants for Data receiving rate and device search rate at the top of `receive.py`

4) Refactored Code so printing the received data to the console is now optional and can be controlled by a function call `print_data`

5) New `handler_closure()` object that uses a programming trick (Python Closures) to pass in the right queue object for the right handler (e.g. the Left queue object for the left handler) this saves us from code duplication @tanjun8802 basically a solution to the program we saw earlier today afternoon lol

6) Cleaned older `connect(device_name, uuid, queue)` code by recoming some stuff as `client.start_notify()` directly supports 'uuid' and we don't need to do anything extra. Docs: [link](https://bleak.readthedocs.io/en/latest/api/client.html#bleak.BleakClient.start_notify)


