### PR TITLE
Fix Bluetooth issues

### DIFF
--- a/src/GIK_Nano/GIK_Nano.ino
+++ b/src/GIK_Nano/GIK_Nano.ino
@@ -321,11 +321,7 @@ void loop() {
 
       unsigned long elapsed = micros() - startTime; //dynamic delay
       long delayNeeded = 35000 - elapsed;  // set the period here in microseconds
-      // Serial.print("Elapsed: ");
-      // Serial.print(elapsed);
-      // Serial.print("ms, Delay: ");
-      // Serial.print(delayNeeded);
-      // Serial.println("ms");
+      
       if (delayNeeded > 1000) {
         delay(delayNeeded / 1000);
       }


### PR DESCRIPTION
This PR is to fix the following issues:

1. #19 The reason behind this was the BLE setup from the Nano side. We forgot to set how often the packets can be sent, and dropout happens because the BLE module is using the default setting, which is slower than what we need. To verify this in the receiver.py I added a section of debugging code for dropout visualisation. More details and experiment results written in #19.

2. #3 Originally thought that the csv writer in receiver.py reacts too slowly in the execution; however, it turns out that it is caused by the Nano side reacting too quickly in sending data. In GIK_Nano.ino we immediately start to send data once it is connected to the receiver, but actually it should wait for the receiver to subscribe before transmitting the samples. Thus, I added a while loop in the Nano script to wait until the BLE is subscribed to the receiver upon sending the first data. Now the csv defo will record the first sample. Experiment results can be found in #3.

3. #10 So far, this issue cannot be recreated, but I have added additional reconnection code to attempt retries in the connection as a handler for this issue when it happens again in the future. When the connection is dropped, it will retry to connect with the same address for 10 times, and if it still fails, rescan to search for Nanos.
